### PR TITLE
Fixes issue related to gift vouchers where user's full name was missing

### DIFF
--- a/upload/catalog/controller/payment/instamojo.php
+++ b/upload/catalog/controller/payment/instamojo.php
@@ -26,7 +26,7 @@ class ControllerPaymentInstamojo extends Controller {
 
       $this->logger->write("$api_key | $auth_token | $private_salt | $custom_field_name");
 
-      $name = substr(trim((html_entity_decode($order_info['shipping_firstname'] . ' ' . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8'))), 0, 20);
+      $name = substr(trim((html_entity_decode($order_info['payment_firstname'] . ' ' . $order_info['payment_lastname'], ENT_QUOTES, 'UTF-8'))), 0, 20);
       $email = substr($order_info['email'], 0, 75);
       $phone = substr(ltrim(html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8'), '+'), 0, 20);
       $amount = $this->currency->format($order_info['total'], $order_info['currency_code'] , false, false);


### PR DESCRIPTION
We should use payment_firstname and payment_lastname rather than shipping_firstname and shipping_lastname.

Related: http://support.instamojo.com/helpdesk/tickets/14409
