### PR TITLE
Added support for failed payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Now you will see a form like this:
 ---
 I will explain **`Order Status`**, **`Checkout Label`** and **`Status`** here and rest of the fields are explained in next sections:  
 
-- **Order Status**:  This is the default status of an order, set its value to **Pending**. After successful payment its value for a particular order will be **Processing**.
+- **Order Status**:  This is the order of the status that you would like to set after a **successful** payment.
 - **Checkout Label**: This is the label users will see during checkout, its default value is **"Pay using Instamojo"**. You can change it to somethint more generic like **"Pay using Credit/Debit Card or Online Banking"**.
 - **Status**:  This is the current status of the module. To use Instamojo during checkout make sure to change it to **enabled**.
 
@@ -79,3 +79,9 @@ This module will everything to a file named **imojo.log** under **system/logs**.
 
 ---
 <sub>`*` This may be different for your **Checkout Label** is different.</sub>
+
+
+### Support
+---
+
+If you're facing some issue with plugin integration then open an ticke at http://support.instamojo.com/. Please do include a **screenshot of the settings** you've done for the plugin in your admin backend as well as the **URL of the Instamojo payment link** you're using with the plugin.

--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ This module will everything to a file named **imojo.log** under **system/logs**.
 ### Support
 ---
 
-If you're facing some issue with plugin integration then open an ticke at http://support.instamojo.com/. Please do include a **screenshot of the settings** you've done for the plugin in your admin backend as well as the **URL of the Instamojo payment link** you're using with the plugin.
+If you're facing some issue with plugin integration then open an ticket at http://support.instamojo.com/. Please do include a **screenshot of the settings** you've done for the plugin in your admin backend as well as the **URL of the Instamojo payment link** you're using with the plugin.

--- a/upload/admin/controller/payment/instamojo.php
+++ b/upload/admin/controller/payment/instamojo.php
@@ -26,6 +26,7 @@ class ControllerPaymentInstamojo extends Controller {
     $this->data['text_enabled'] = $this->language->get('text_enabled');
     $this->data['text_disabled'] = $this->language->get('text_disabled');
     $this->data['entry_status'] = $this->language->get('entry_status');
+    $this->data['entry_sort_order'] = $this->language->get('entry_sort_order');
  
     $this->data['action'] = $this->url->link('payment/instamojo', 'token=' . $this->session->data['token'], 'SSL');
     $this->data['cancel'] = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL');
@@ -77,6 +78,12 @@ class ControllerPaymentInstamojo extends Controller {
     } else {
       $this->data['instamojo_order_status_id'] = $this->config->get('instamojo_order_status_id');
     }
+
+    if (isset($this->request->post['instamojo_sort_order'])) {
+            $this->data['instamojo_sort_order'] = $this->request->post['instamojo_sort_order'];
+        } else {
+            $this->data['instamojo_sort_order'] = $this->config->get('instamojo_sort_order');
+        }
  
     $this->load->model('localisation/order_status');
     $this->data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();

--- a/upload/admin/language/english/payment/instamojo.php
+++ b/upload/admin/language/english/payment/instamojo.php
@@ -13,6 +13,7 @@ $_['instamojo_custom_field'] = 'Custom Field';
 
 $_['entry_status'] = 'Status';
 $_['entry_order_status'] = 'Order Status';
+$_['entry_sort_order'] = 'Sort Order';
  
 $_['text_button_save'] = 'Save';
 $_['text_button_cancel'] = 'Cancel';


### PR DESCRIPTION
- Fixed the issue of **Order Status** field, now it is going to be used to set the status of a successful order.
- Let's not trim out `+` from the phone numbers
- Added support for failed payments.
- Added sort option.
- Added trailing `/` to payment detail API request to prevent a rare cURL error.
